### PR TITLE
test - parallel data implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ This work was supported by COST Action CA21167 - Universality, diversity and idi
 
 # Changelog
 
+* 2025-09-04 v2.16
+  * add parallel corpus information to machine-readable metadata
+  * add parallel data support with parallel_id metadata 
 * 2025-05-15 v2.16
   * Initial release in Universal Dependencies.
 
@@ -24,6 +27,7 @@ This work was supported by COST Action CA21167 - Universality, diversity and idi
 Data available since: UD v2.16
 License: CC BY-SA 4.0
 Includes text: yes
+Parallel: cairo tuecl
 Genre: grammar-examples
 Lemmas: manual native
 UPOS: manual native

--- a/uz_tuecl-ud-test.conllu
+++ b/uz_tuecl-ud-test.conllu
@@ -598,12 +598,14 @@
 6	.	.	PUNCT	_	_	5	punct	_	_
 
 # sent_id = 1
+# parallel_id = tuecl/1
 # text = Deniz uxladi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	2	nsubj	_	_
 2	uxladi	uxla	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 2
+# parallel_id = tuecl/2
 # text = Deniz kitob oʻqiyapti.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	3	nsubj	_	_
 2	kitob	kitob	NOUN	_	Case=Nom|Number=Sing	3	obj	_	_
@@ -611,6 +613,7 @@
 4	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = 3
+# parallel_id = tuecl/3
 # text = Deniz oqshomlari uyda kitob oʻqiydi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	5	nsubj	_	_
 2	oqshomlari	oqshom	NOUN	_	Case=Nom|Number=Plur	5	obl	_	_
@@ -620,6 +623,7 @@
 6	.	.	PUNCT	_	_	5	punct	_	_
 
 # sent_id = 4
+# parallel_id = tuecl/4
 # text = Deniz ukasiga kitobni berdi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	4	nsubj	_	_
 2	ukasiga	uka	NOUN	_	Case=Dat|Number=Sing	4	obl	_	_
@@ -628,6 +632,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 5
+# parallel_id = tuecl/5
 # text = Deniz kitobni uyiga olib ketdi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	5	nsubj	_	_
 2	kitobni	kitob	NOUN	_	Case=Acc|Number=Sing	5	obj	_	_
@@ -637,6 +642,7 @@
 6	.	.	PUNCT	_	_	5	punct	_	_
 
 # sent_id = 6
+# parallel_id = tuecl/6
 # text = Oʻqituvchi bolalarga dars berdi.
 1	Oʻqituvchi	oʻqituvchi	NOUN	_	Case=Nom|Number=Sing	4	nsubj	_	_
 2	bolalarga	bola	NOUN	_	Case=Dat|Number=Plur	4	obl	_	_
@@ -645,6 +651,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 7
+# parallel_id = tuecl/7
 # text = Deniz doʻstiga kitob sotib oldi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	5	nsubj	_	_
 2	doʻstiga	doʻst	NOUN	_	Case=Dat|Number=Sing	5	obl	_	_
@@ -654,6 +661,7 @@
 6	.	.	PUNCT	_	_	5	punct	_	_
 
 # sent_id = 8
+# parallel_id = tuecl/8
 # text = Deniz akasi bilan yarashdi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	4	nsubj	_	_
 2	akasi	aka	NOUN	_	Case=Nom|Number=Sing|Poss=Yes	4	obl	_	_
@@ -662,6 +670,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 9
+# parallel_id = tuecl/9
 # text = Deniz doʻstlaridan shikoyat qildi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	4	nsubj	_	_
 2	doʻstlaridan	doʻst	NOUN	_	Case=Abl|Number=Plur|Poss=Yes	4	obl	_	_
@@ -670,6 +679,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 10
+# parallel_id = tuecl/10
 # text = Deniz barvaqt uxladi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	3	nsubj	_	_
 2	barvaqt	barvaqt	ADV	_	_	3	advmod	_	_
@@ -677,6 +687,7 @@
 4	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = 11
+# parallel_id = tuecl/11
 # text = Deniz doʻsti tayyorlagan ovqatdan ikki likopcha yedi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	7	nsubj	_	_
 2	doʻsti	doʻst	NOUN	_	Case=Nom|Number=Sing|Poss=Yes	3	nsubj	_	_
@@ -688,6 +699,7 @@
 8	.	.	PUNCT	_	_	7	punct	_	_
 
 # sent_id = 12
+# parallel_id = tuecl/12
 # text = Deniz uch soat uxladi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	4	nsubj	_	_
 2	uch	uch	NUM	_	NumType=Card	3	nummod	_	_
@@ -696,6 +708,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 13
+# parallel_id = tuecl/13
 # text = Deniz juda chaqqon.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	3	nsubj	_	_
 2	juda	juda	ADV	_	_	3	advmod	_	_
@@ -703,18 +716,21 @@
 4	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = 14
+# parallel_id = tuecl/14
 # text = Deniz talaba.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	2	nsubj	_	_
 2	talaba	talaba	NOUN	_	Case=Nom|Number=Sing	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 15
+# parallel_id = tuecl/15
 # text = Deniz talabadir.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	2	nsubj	_	_
 2	talabadir	talaba	NOUN	_	Case=Nom|Number=Sing	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 16
+# parallel_id = tuecl/16
 # text = Deniz shifokor boʻladi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	3	nsubj	_	_
 2	shifokor	shifokor	NOUN	_	Case=Nom|Number=Sing	3	xcomp	_	_
@@ -722,12 +738,14 @@
 4	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = 17
+# parallel_id = tuecl/17
 # text = Deniz uyda.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	2	nsubj	_	_
 2	uyda	uy	NOUN	_	Case=Loc|Number=Sing	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 18
+# parallel_id = tuecl/18
 # text = Deniz uyda edi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	2	nsubj	_	_
 2	uyda	uy	NOUN	_	Case=Loc|Number=Sing	0	root	_	_
@@ -735,6 +753,7 @@
 4	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 19
+# parallel_id = tuecl/19
 # text = Deniz uyda boʻlgandi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	2	nsubj	_	_
 2	uyda	uy	NOUN	_	Case=Loc|Number=Sing	0	root	_	_
@@ -742,6 +761,7 @@
 4	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 20
+# parallel_id = tuecl/20
 # text = Sovgʻa Deniz uchun edi.
 1	Sovgʻa	sovgʻa	NOUN	_	Case=Nom|Number=Sing	2	nsubj	_	_
 2	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	0	root	_	_
@@ -750,12 +770,14 @@
 5	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 21
+# parallel_id = tuecl/21
 # text = Deniz uxlagandi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	2	nsubj	_	_
 2	uxlagandi	uxla	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 22
+# parallel_id = tuecl/22
 # text = Deniz uxlagan edi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	2	nsubj	_	_
 2	uxlagan	uxla	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Part	0	root	_	_
@@ -763,6 +785,7 @@
 4	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 23
+# parallel_id = tuecl/23
 # text = Deniz uxlagan boʻladi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	2	nsubj	_	_
 2	uxlagan	uxla	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Part	0	root	_	_
@@ -770,6 +793,7 @@
 4	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 24
+# parallel_id = tuecl/24
 # text = Onasining orzusi Denizning yaxshi maktabda oʻqishi edi.
 1	Onasining	ona	NOUN	_	Case=Gen|Number=Sing|Poss=Yes	2	nmod	_	_
 2	orzusi	orzu	NOUN	_	Case=Nom|Number=Sing|Poss=Yes	6	nsubj	_	_
@@ -781,6 +805,7 @@
 8	.	.	PUNCT	_	_	6	punct	_	_
 
 # sent_id = 25
+# parallel_id = tuecl/25
 # text = Denizning yaxshi maktabda oʻqimasligi onasini havotirga solardi.
 1	Denizning	Deniz	PROPN	_	Case=Gen|Number=Sing	4	nmod	_	_
 2	yaxshi	yaxshi	ADJ	_	_	3	amod	_	_
@@ -792,6 +817,7 @@
 8	.	.	PUNCT	_	_	7	punct	_	_
 
 # sent_id = 26
+# parallel_id = tuecl/26
 # text = Stolda koʻp kitob bor, kitob javonida esa yoʻq.
 1	Stolda	stol	NOUN	_	Case=Loc|Number=Sing	4	obl	_	_
 2	koʻp	koʻp	ADJ	_	_	3	amod	_	_
@@ -805,6 +831,7 @@
 10	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 27
+# parallel_id = tuecl/27
 # text = Denizning hech qanday kitobi yoʻq.
 1	Denizning	Deniz	PROPN	_	Case=Gen|Number=Sing	4	nmod:poss	_	_
 2	hech	hech	DET	_	PronType=Neg	3	compound	_	_
@@ -814,6 +841,7 @@
 6	.	.	PUNCT	_	_	5	punct	_	_
 
 # sent_id = 28
+# parallel_id = tuecl/28
 # text = Deniz uyda emasdi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	2	nsubj	_	_
 2	uyda	uy	NOUN	_	Case=Loc|Number=Sing	0	root	_	_
@@ -821,6 +849,7 @@
 4	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 29
+# parallel_id = tuecl/29
 # text = Deniz vaqtida uxlamaydi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	3	nsubj	_	_
 2	vaqtida	vaqt	NOUN	_	Case=Loc|Number=Sing	3	obl	_	_
@@ -828,6 +857,7 @@
 4	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = 30
+# parallel_id = tuecl/30
 # text = Deniz uxlay olmaydi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	3	nsubj	_	_
 2	uxlay	uxla	VERB	_	VerbForm=Conv	3	compound	_	_
@@ -835,6 +865,7 @@
 4	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = 31
+# parallel_id = tuecl/31
 # text = Deniz vaqtida uxlay olmasligi mumkin.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	4	nsubj	_	_
 2	vaqtida	vaqt	NOUN	_	Case=Loc|Number=Sing	4	obl	_	_
@@ -844,6 +875,7 @@
 6	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 32
+# parallel_id = tuecl/32
 # text = Deniz onasini koʻrmay qoldi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	4	nsubj	_	_
 2	onasini	ona	NOUN	_	Case=Acc|Number=Sing	4	obj	_	_
@@ -852,6 +884,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 33
+# parallel_id = tuecl/33
 # text = Deniz onasini koʻrib qolmadi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	4	nsubj	_	_
 2	onasini	ona	NOUN	_	Case=Acc|Number=Sing|Poss=Yes	4	obj	_	_
@@ -860,6 +893,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 34
+# parallel_id = tuecl/34
 # text = Deniz onasini koʻrmay qolmadi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	4	nsubj	_	_
 2	onasini	ona	NOUN	_	Case=Acc|Number=Sing|Poss=Yes	4	obj	_	_
@@ -868,12 +902,14 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 35
+# parallel_id = tuecl/35
 # text = Oʻqiganlarini tushunmaydi.
 1	Oʻqiganlarini	oʻqi	VERB	_	Case=Acc|Number=Plur|VerbForm=Part	2	xcomp	_	_
 2	tushunmaydi	tushun	VERB	_	Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 36
+# parallel_id = tuecl/36
 # text = Oʻqiganlarini tushungani yoʻq.
 1	Oʻqiganlarini	oʻqi	VERB	_	Case=Acc|Number=Plur|VerbForm=Part	2	xcomp	_	_
 2	tushungani	tushun	VERB	_	Number=Sing|Person=3|Tense=Past|VerbForm=Part	0	root	_	_
@@ -881,6 +917,7 @@
 4	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 37
+# parallel_id = tuecl/37
 # text = Oʻqiganlarini tushunmaydi emas.
 1	Oʻqiganlarini	oʻqi	VERB	_	Case=Acc|Number=Plur|VerbForm=Part	2	xcomp	_	_
 2	tushunmaydi	tushun	VERB	_	Mood=Ind|Number=Sing|Person=3|Polarity=Neg|Tense=Pres	0	root	_	_
@@ -888,6 +925,7 @@
 4	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 38
+# parallel_id = tuecl/38
 # text = Oʻqishni emas, rasm chizishni yaxshi koʻradi.
 1	Oʻqishni	oʻqi	VERB	_	Case=Acc|VerbForm=Vnoun	7	xcomp	_	_
 2	emas	emas	AUX	_	Polarity=Neg	1	cop	_	SpaceAfter=No
@@ -899,6 +937,7 @@
 8	.	.	PUNCT	_	_	7	punct	_	_
 
 # sent_id = 39
+# parallel_id = tuecl/39
 # text = Deniz xonada emasdi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	2	nsubj	_	_
 2	xonada	xona	NOUN	_	Case=Loc|Number=Sing	0	root	_	_
@@ -906,6 +945,7 @@
 4	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 40
+# parallel_id = tuecl/40
 # text = Deniz xonada yoʻq edi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	2	nsubj	_	_
 2	xonada	xona	NOUN	_	Case=Loc|Number=Sing	3	obl	_	_
@@ -914,6 +954,7 @@
 5	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = 41
+# parallel_id = tuecl/41
 # text = Deniz kitob oʻqimoqchi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	3	nsubj	_	_
 2	kitob	kitob	NOUN	_	Case=Nom|Number=Sing	3	obj	_	_
@@ -921,6 +962,7 @@
 4	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = 42
+# parallel_id = tuecl/42
 # text = Deniz kitob oʻqishni xohlaydi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	4	nsubj	_	_
 2	kitob	kitob	NOUN	_	Case=Nom|Number=Sing	3	obj	_	_
@@ -929,6 +971,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 43
+# parallel_id = tuecl/43
 # text = Deniz otasining kitob oʻqib berishini xohlaydi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	6	nsubj	_	_
 2	otasining	ota	NOUN	_	Case=Gen|Number=Sing|Poss=Yes	5	nsubj	_	_
@@ -939,6 +982,7 @@
 7	.	.	PUNCT	_	_	6	punct	_	_
 
 # sent_id = 44
+# parallel_id = tuecl/44
 # text = Deniz oʻzi bilan oʻzi boʻlishni yaxshi koʻradi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	7	nsubj	_	_
 2	oʻzi	oʻzi	PRON	_	Case=Nom|Number=Sing|Person=3|PronType=Prs	4	compound	_	_
@@ -950,6 +994,7 @@
 8	.	.	PUNCT	_	_	7	punct	_	_
 
 # sent_id = 45
+# parallel_id = tuecl/45
 # text = Onasining kitob oʻqishi Denizning uxlashini osonlashtiradi.
 1	Onasining	ona	NOUN	_	Case=Gen|Number=Sing|Poss=Yes	3	nsubj	_	_
 2	kitob	kitob	NOUN	_	Case=Nom|Number=Sing	3	obj	_	_
@@ -960,6 +1005,7 @@
 7	.	.	PUNCT	_	_	6	punct	_	_
 
 # sent_id = 46
+# parallel_id = tuecl/46
 # text = Bolalarga kitob oʻqish ularning rivojlanishi uchun muhimdir.
 1	Bolalarga	bola	NOUN	_	Case=Dat|Number=Plur	3	obl	_	_
 2	kitob	kitob	NOUN	_	Case=Nom|Number=Sing	3	obj	_	_
@@ -971,6 +1017,7 @@
 8	.	.	PUNCT	_	_	7	punct	_	_
 
 # sent_id = 47
+# parallel_id = tuecl/47
 # text = Deniz kitob oʻqib uxlayapti.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	4	nsubj	_	_
 2	kitob	kitob	NOUN	_	Case=Nom|Number=Sing	3	obj	_	_
@@ -979,6 +1026,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 48
+# parallel_id = tuecl/48
 # text = Deniz taʼtil ekanligini unutib, maktabga ketgan.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	7	nsubj	_	_
 2	taʼtil	taʼtil	NOUN	_	Case=Nom|Number=Sing	4	obj	_	_
@@ -990,6 +1038,7 @@
 8	.	.	PUNCT	_	_	7	punct	_	_
 
 # sent_id = 49
+# parallel_id = tuecl/49
 # text = Deniz taʼtil ekanligini unutib, sumkasini olib, maktabga ketgan.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	10	nsubj	_	_
 2	taʼtil	taʼtil	NOUN	_	Case=Nom|Number=Sing	4	obj	_	_
@@ -1004,6 +1053,7 @@
 11	.	.	PUNCT	_	_	10	punct	_	_
 
 # sent_id = 50
+# parallel_id = tuecl/50
 # text = Deniz kech uxlasa, maktabga kechikadi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	3	nsubj	_	_
 2	kech	kech	ADV	_	_	3	advmod	_	_
@@ -1014,6 +1064,7 @@
 7	.	.	PUNCT	_	_	6	punct	_	_
 
 # sent_id = 51
+# parallel_id = tuecl/51
 # text = Deniz kech uxlasa, maktabga kech qoladi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	3	nsubj	_	_
 2	kech	kech	ADV	_	_	3	advmod	_	_
@@ -1025,6 +1076,7 @@
 8	.	.	PUNCT	_	_	7	punct	_	_
 
 # sent_id = 52
+# parallel_id = tuecl/52
 # text = Agar bola uxlaganida, kino koʻrgan boʻlardik.
 1	Agar	agar	SCONJ	_	_	3	mark	_	_
 2	bola	bola	NOUN	_	Case=Nom|Number=Sing	3	nsubj	_	_
@@ -1036,6 +1088,7 @@
 8	.	.	PUNCT	_	_	7	punct	_	_
 
 # sent_id = 53
+# parallel_id = tuecl/53
 # text = Agar bola uyga ketmasdan uxlab qolsa, borganimizda uygʻotishimiz kerak boʻladi.
 1	Agar	agar	SCONJ	_	_	6	mark	_	_
 2	bola	bola	NOUN	_	Case=Nom|Number=Sing	6	nsubj	_	_
@@ -1051,12 +1104,14 @@
 12	.	.	PUNCT	_	_	9	punct	_	_
 
 # sent_id = 54
+# parallel_id = tuecl/54
 # text = Hechqisi yoʻq.
 1	Hechqisi	hechqisi	PRON	_	PronType=Neg	2	compound	_	_
 2	yoʻq	yoʻq	ADJ	_	_	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 55
+# parallel_id = tuecl/55
 # text = Hech qaysisi yoʻq.
 1	Hech	hech	DET	_	PronType=Neg	2	compound	_	_
 2	qaysisi	qaysi	PRON	_	Case=Nom|Number=Sing|PronType=Int	3	nsubj	_	_
@@ -1064,6 +1119,7 @@
 4	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = 56
+# parallel_id = tuecl/56
 # text = Menimcha, bola erta uxlaydi.
 1	Menimcha	menimcha	ADV	_	_	5	discourse	_	SpaceAfter=No
 2	,	,	PUNCT	_	_	1	punct	_	_
@@ -1073,6 +1129,7 @@
 6	.	.	PUNCT	_	_	5	punct	_	_
 
 # sent_id = 57
+# parallel_id = tuecl/57
 # text = Deniz birodarini yomon koʻradi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	4	nsubj	_	_
 2	birodarini	birodar	NOUN	_	Case=Acc|Number=Plur|Poss=Yes	4	obj	_	_
@@ -1081,6 +1138,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 58
+# parallel_id = tuecl/58
 # text = Ertangi kunni intiqlik bilan kutaman.
 1	Ertangi	ertangi	ADJ	_	_	2	amod	_	_
 2	kunni	kun	NOUN	_	Case=Acc|Number=Sing	5	obj	_	_
@@ -1090,6 +1148,7 @@
 6	.	.	PUNCT	_	_	5	punct	_	_
 
 # sent_id = 59
+# parallel_id = tuecl/59
 # text = Kasalxona davlat xizmatiga topshirildi.
 1	Kasalxona	kasalxona	NOUN	_	Case=Nom|Number=Sing	4	nsubj:pass	_	_
 2	davlat	davlat	NOUN	_	Case=Nom|Number=Sing	3	nmod	_	_
@@ -1098,6 +1157,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 60
+# parallel_id = tuecl/60
 # text = Katta uydagi bola kitob oʻqiyapti.
 1	Katta	katta	ADJ	_	_	2	amod	_	_
 2	uydagi	uy	NOUN	_	Case=Loc|Number=Sing	3	obl	_	_
@@ -1107,6 +1167,7 @@
 6	.	.	PUNCT	_	_	5	punct	_	_
 
 # sent_id = 61
+# parallel_id = tuecl/61
 # text = Katta uydagi kitob oʻqiyapti.
 1	Katta	katta	ADJ	_	_	2	amod	_	_
 2	uydagi	uy	NOUN	_	Case=Loc|Number=Sing	4	nsubj	_	_
@@ -1115,6 +1176,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 62
+# parallel_id = tuecl/62
 # text = Katta uydagi bolaning sochi sargʻish, kichik uydaginiki jigarrang.
 1	Katta	katta	ADJ	_	_	2	amod	_	_
 2	uydagi	uy	NOUN	_	Case=Loc|Number=Sing	3	obl	_	_
@@ -1128,6 +1190,7 @@
 10	.	.	PUNCT	_	_	5	punct	_	_
 
 # sent_id = 63
+# parallel_id = tuecl/63
 # text = Piyozni toʻq pushti rangga aylanguniga qadar qovuring.
 1	Piyozni	piyoz	NOUN	_	Case=Acc|Number=Sing	7	obj	_	_
 2	toʻq	toʻq	ADJ	_	_	3	amod	_	_
@@ -1139,6 +1202,7 @@
 8	.	.	PUNCT	_	_	7	punct	_	_
 
 # sent_id = 64
+# parallel_id = tuecl/64
 # text = Uyning oldida uchta mashina uchun toʻxtash joyi bor.
 1	Uyning	uy	NOUN	_	Case=Gen|Number=Sing	2	nmod:poss	_	_
 2	oldida	old	NOUN	_	Case=Loc|Number=Sing	8	obl	_	_
@@ -1151,6 +1215,7 @@
 9	.	.	PUNCT	_	_	8	punct	_	_
 
 # sent_id = 65
+# parallel_id = tuecl/65
 # text = Muqaddas kitobsiz dinlar ham bor.
 1	Muqaddas	muqaddas	ADJ	_	_	2	amod	_	_
 2	kitobsiz	kitobsiz	ADJ	_	_	3	amod	_	_
@@ -1160,6 +1225,7 @@
 6	.	.	PUNCT	_	_	5	punct	_	_
 
 # sent_id = 66
+# parallel_id = tuecl/66
 # text = Kichkina derazali uyda yorugʻlik yetarli emas.
 1	Kichkina	kichkina	ADJ	_	_	2	amod	_	_
 2	derazali	derazali	ADJ	_	_	3	amod	_	_
@@ -1170,6 +1236,7 @@
 7	.	.	PUNCT	_	_	5	punct	_	_
 
 # sent_id = 67
+# parallel_id = tuecl/67
 # text = Deniz uyga keldimi?
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	3	nsubj	_	_
 2	uyga	uy	NOUN	_	Case=Dat|Number=Sing	3	obl	_	_
@@ -1177,6 +1244,7 @@
 4	?	?	PUNCT	_	_	3	punct	_	_
 
 # sent_id = 68
+# parallel_id = tuecl/68
 # text = Deniz uyga kelganmidi?
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	3	nsubj	_	_
 2	uyga	uy	NOUN	_	Case=Dat|Number=Sing	3	obl	_	_
@@ -1184,18 +1252,21 @@
 4	?	?	PUNCT	_	_	3	punct	_	_
 
 # sent_id = 69
+# parallel_id = tuecl/69
 # text = Deniz uydami?
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	2	nsubj	_	_
 2	uydami	uy	NOUN	_	Case=Loc|Number=Sing	0	root	_	SpaceAfter=No
 3	?	?	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 70
+# parallel_id = tuecl/70
 # text = Deniz uydamikan?
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	2	nsubj	_	_
 2	uydamikan	uy	NOUN	_	Case=Loc|Number=Sing	0	root	_	SpaceAfter=No
 3	?	?	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 71
+# parallel_id = tuecl/71
 # text = Deniz uyda edimi?
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	2	nsubj	_	_
 2	uyda	uy	NOUN	_	Case=Loc|Number=Sing	0	root	_	_
@@ -1203,6 +1274,7 @@
 4	?	?	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 72
+# parallel_id = tuecl/72
 # text = Deniz uyda emasmidi?
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	2	nsubj	_	_
 2	uyda	uy	NOUN	_	Case=Loc|Number=Sing	0	root	_	_
@@ -1210,6 +1282,7 @@
 4	?	?	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 73
+# parallel_id = tuecl/73
 # text = Deniz uyda yoʻqmi?
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	3	nsubj	_	_
 2	uyda	uy	NOUN	_	Case=Loc|Number=Sing	3	obl	_	_
@@ -1217,6 +1290,7 @@
 4	?	?	PUNCT	_	_	3	punct	_	_
 
 # sent_id = 74
+# parallel_id = tuecl/74
 # text = Uyda non bormi?
 1	Uyda	uy	NOUN	_	Case=Loc|Number=Sing	3	obl	_	_
 2	non	non	NOUN	_	Case=Nom|Number=Sing	3	nsubj	_	_
@@ -1224,6 +1298,7 @@
 4	?	?	PUNCT	_	_	3	punct	_	_
 
 # sent_id = 75
+# parallel_id = tuecl/75
 # text = Non uyda bormi?
 1	Non	non	NOUN	_	Case=Nom|Number=Sing	3	nsubj	_	_
 2	uyda	uy	NOUN	_	Case=Loc|Number=Sing	3	obl	_	_
@@ -1231,6 +1306,7 @@
 4	?	?	PUNCT	_	_	3	punct	_	_
 
 # sent_id = 76
+# parallel_id = tuecl/76
 # text = Uyda non bormi?
 1	Uyda	uy	NOUN	_	Case=Loc|Number=Sing	3	obl	_	_
 2	non	non	NOUN	_	Case=Nom|Number=Sing	3	nsubj	_	_
@@ -1238,12 +1314,14 @@
 4	?	?	PUNCT	_	_	3	punct	_	_
 
 # sent_id = 77
+# parallel_id = tuecl/77
 # text = Oʻqiganingizni tushundingizmi?
 1	Oʻqiganingizni	oʻqi	VERB	_	Case=Acc|VerbForm=Part	2	xcomp	_	_
 2	tushundingizmi	tushun	VERB	_	Mood=Int|Number=Plur|Person=2|Tense=Past	0	root	_	SpaceAfter=No
 3	?	?	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 78
+# parallel_id = tuecl/78
 # text = Ertalab Deniz kitobni Oyxonga berdimi?
 1	Ertalab	ertalab	ADV	_	_	5	advmod	_	_
 2	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	5	nsubj	_	_
@@ -1253,6 +1331,7 @@
 6	?	?	PUNCT	_	_	5	punct	_	_
 
 # sent_id = 79
+# parallel_id = tuecl/79
 # text = Ertalab kitobni Oyxonga Deniz berdimi?
 1	Ertalab	ertalab	ADV	_	_	5	advmod	_	_
 2	kitobni	kitob	NOUN	_	Case=Acc|Number=Sing	5	obj	_	_
@@ -1262,6 +1341,7 @@
 6	?	?	PUNCT	_	_	5	punct	_	_
 
 # sent_id = 80
+# parallel_id = tuecl/80
 # text = Ertalab Deniz Oyxonga kitobni berdimi?
 1	Ertalab	ertalab	ADV	_	_	5	advmod	_	_
 2	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	5	nsubj	_	_
@@ -1271,6 +1351,7 @@
 6	?	?	PUNCT	_	_	5	punct	_	_
 
 # sent_id = 81
+# parallel_id = tuecl/81
 # text = Ertalab Deniz kitobni Oyxonga berdimi?
 1	Ertalab	ertalab	ADV	_	_	5	advmod	_	_
 2	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	5	nsubj	_	_
@@ -1280,6 +1361,7 @@
 6	?	?	PUNCT	_	_	5	punct	_	_
 
 # sent_id = 82
+# parallel_id = tuecl/82
 # text = Deniz kitobni Oyxonga ertalab berdimi?
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	5	nsubj	_	_
 2	kitobni	kitob	NOUN	_	Case=Acc|Number=Sing	5	obj	_	_
@@ -1289,6 +1371,7 @@
 6	?	?	PUNCT	_	_	5	punct	_	_
 
 # sent_id = 83
+# parallel_id = tuecl/83
 # text = Menga koʻkni bera olasizmi?
 1	Menga	men	PRON	_	Case=Dat|Number=Sing	4	obl	_	_
 2	koʻkni	koʻk	ADJ	_	Case=Acc	4	obj	_	_
@@ -1297,6 +1380,7 @@
 5	?	?	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 84
+# parallel_id = tuecl/84
 # text = Buning koʻk rangi chiroyliroq.
 1	Buning	bu	PRON	_	Case=Gen|Number=Sing|PronType=Dem	3	nmod:poss	_	_
 2	koʻk	koʻk	ADJ	_	_	3	amod	_	_
@@ -1305,6 +1389,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 85
+# parallel_id = tuecl/85
 # text = Mening mashinam Deniznikining koʻki.
 1	Mening	men	PRON	_	Case=Gen|Number=Sing|Person=1|PronType=Prs	2	nmod:poss	_	_
 2	mashinam	mashina	NOUN	_	Case=Nom|Number=Sing|Poss=Yes	4	nsubj	_	_
@@ -1313,12 +1398,14 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 86
+# parallel_id = tuecl/86
 # text = Kitob oʻqilyapti.
 1	Kitob	kitob	NOUN	_	Case=Nom|Number=Sing	2	nsubj:pass	_	_
 2	oʻqilyapti	oʻqi	VERB	_	Aspect=Prog|Mood=Ind|Tense=Pres|Voice=Pass	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 87
+# parallel_id = tuecl/87
 # text = Kitob barcha maktablarda oʻqitiladi.
 1	Kitob	kitob	NOUN	_	Case=Nom|Number=Sing	4	nsubj:pass	_	_
 2	barcha	barcha	DET	_	PronType=Tot	3	det	_	_
@@ -1327,24 +1414,28 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 88
+# parallel_id = tuecl/88
 # text = Denizni uxlatishdi.
 1	Denizni	Deniz	PROPN	_	Case=Acc|Number=Sing	2	obj	_	_
 2	uxlatishdi	uxla	VERB	_	Mood=Ind|Number=Plur|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 89
+# parallel_id = tuecl/89
 # text = Ular ketdi.
 1	Ular	u	PRON	_	Case=Nom|Number=Plur|Person=3|PronType=Prs	2	nsubj	_	_
 2	ketdi	ket	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 90
+# parallel_id = tuecl/90
 # text = U ketdi.
 1	U	u	PRON	_	Case=Nom|Number=Sing|Person=3|PronType=Prs	2	nsubj	_	_
 2	ketdi	ket	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Past|VerbForm=Fin	0	root	_	SpaceAfter=No
 3	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = 91
+# parallel_id = tuecl/91
 # text = Deniz bu yerga kelib, boʻsh vaqtlarida kitob oʻqir edi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	4	nsubj	_	_
 2	bu	bu	DET	_	PronType=Dem	3	det	_	_
@@ -1359,6 +1450,7 @@
 11	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 92
+# parallel_id = tuecl/92
 # text = Siz biz bilan kelasiz, toʻgʻrimi?
 1	Siz	siz	PRON	_	Case=Nom|Number=Sing|Person=2|PronType=Prs	4	nsubj	_	_
 2	biz	biz	PRON	_	Case=Nom|Number=Plur	4	obl	_	_
@@ -1369,6 +1461,7 @@
 7	?	?	PUNCT	_	_	6	punct	_	_
 
 # sent_id = 93
+# parallel_id = tuecl/93
 # text = Bu shunday kitobki, uni oʻqigan dunyoga boshqacha nazar bilan qaraydi.
 1	Bu	bu	PRON	_	Case=Nom|Number=Sing|PronType=Dem	3	nsubj	_	_
 2	shunday	shunday	DET	_	PronType=Dem	3	amod	_	_
@@ -1384,6 +1477,7 @@
 12	.	.	PUNCT	_	_	11	punct	_	_
 
 # sent_id = 94
+# parallel_id = tuecl/94
 # text = Sen avval tozalashni tugat, biz dazmollaymiz.
 1	Sen	sen	PRON	_	Case=Nom|Number=Sing|Person=2|PronType=Prs	4	nsubj	_	_
 2	avval	avval	ADV	_	_	4	advmod	_	_
@@ -1395,6 +1489,7 @@
 8	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = 95
+# parallel_id = tuecl/95
 # text = Aytishlaricha, Oysha Xoqonga uy vazifalarini bajarishda yordam bergan.
 1	Aytishlaricha	ayt	VERB	_	Number=Plur|Person=3	9	discourse	_	SpaceAfter=No
 2	,	,	PUNCT	_	_	1	punct	_	_
@@ -1408,6 +1503,7 @@
 10	.	.	PUNCT	_	_	9	punct	_	_
 
 # sent_id = 96
+# parallel_id = tuecl/96
 # text = Umuman olganda, bu muvaffaqiyatli film edi.
 1	Umuman	umuman	ADV	_	_	6	advmod	_	_
 2	olganda	ol	VERB	_	_	1	compound	_	SpaceAfter=No
@@ -1419,6 +1515,7 @@
 8	.	.	PUNCT	_	_	6	punct	_	_
 
 # sent_id = 97
+# parallel_id = tuecl/97
 # text = Olma daraxtlari aprel-may oylarida gullab, oʻzaro changlanadi.
 1	Olma	olma	NOUN	_	Case=Nom|Number=Sing	2	nmod	_	_
 2	daraxtlari	daraxt	NOUN	_	Case=Nom|Number=Plur|Poss=Yes	7	nsubj	_	_

--- a/uz_tuecl-ud-test.conllu
+++ b/uz_tuecl-ud-test.conllu
@@ -1,4 +1,5 @@
 # sent_id = cairo-1
+# parallel_id = cairo/1
 # text = Qiz doʻstiga xat yozdi.
 1	Qiz	qiz	NOUN	_	Case=Nom|Number=Sing	4	nsubj	_	_
 2	doʻstiga	doʻst	NOUN	_	Case=Dat|Number=Sing	4	obl	_	_
@@ -7,6 +8,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = cairo-2
+# parallel_id = cairo/2
 # text = Menimcha, yomgʻir yogʻyapti.
 1	Menimcha	menimcha	ADV	_	_	4	discourse	_	SpaceAfter=No
 2	,	,	PUNCT	_	_	1	punct	_	_
@@ -15,6 +17,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = cairo-3.1
+# parallel_id = cairo/3/alt1
 # text = U chekish va ichishni tashlashga harakat qildi.
 1	U	u	PRON	_	Case=Nom|Number=Sing|Person=3|PronType=Prs	7	nsubj	_	_
 2	chekish	chek	VERB	_	Case=Nom|VerbForm=Vnoun	5	xcomp	_	_
@@ -26,6 +29,7 @@
 8	.	.	PUNCT	_	_	7	punct	_	_
 
 # sent_id = cairo-3.2
+# parallel_id = cairo/3/alt2
 # text = Chekish va ichishni tashlashga harakat qildi.
 1	Chekish	chek	VERB	_	Case=Nom|VerbForm=Vnoun	4	xcomp	_	_
 2	va	va	CCONJ	_	_	3	cc	_	_
@@ -36,6 +40,7 @@
 7	.	.	PUNCT	_	_	6	punct	_	_
 
 # sent_id = cairo-4.1
+# parallel_id = cairo/4/alt1
 # text = Sen ketishni istaysanmi?
 1	Sen	sen	PRON	_	Case=Nom|Number=Sing|Person=2|PronType=Prs	3	nsubj	_	_
 2	ketishni	ket	VERB	_	Case=Acc|VerbForm=Vnoun	3	xcomp	_	_
@@ -43,12 +48,14 @@
 4	?	?	PUNCT	_	_	3	punct	_	_
 
 # sent_id = cairo-4.2
+# parallel_id = cairo/4/alt2
 # text = Ketishni istaysanmi?
 1	Ketishni	ket	VERB	_	Case=Acc|VerbForm=Vnoun	2	xcomp	_	_
 2	istaysanmi	ista	VERB	_	Mood=Int|Number=Sing|Person=2|Tense=Pres	0	root	_	SpaceAfter=No
 3	?	?	PUNCT	_	_	2	punct	_	_
 
 # sent_id = cairo-5
+# parallel_id = cairo/5
 # text = Sem, derazani och!
 1	Sem	Sem	PROPN	_	Case=Nom|Number=Sing	4	vocative	_	SpaceAfter=No
 2	,	,	PUNCT	_	_	1	punct	_	_
@@ -57,6 +64,7 @@
 5	!	!	PUNCT	_	_	4	punct	_	_
 
 # sent_id = cairo-6.1
+# parallel_id = cairo/6/alt1
 # text = U eriga mashinani yuvdirdi.
 1	U	u	PRON	_	Case=Nom|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	eriga	er	NOUN	_	Case=Dat|Number=Sing	4	obl	_	_
@@ -65,6 +73,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = cairo-6.2
+# parallel_id = cairo/6/alt2
 # text = Eriga mashinani yuvdirdi.
 1	Eriga	er	NOUN	_	Case=Dat|Number=Sing	3	obl	_	_
 2	mashinani	mashina	NOUN	_	Case=Acc|Number=Sing	3	obj	_	_
@@ -72,6 +81,7 @@
 4	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = cairo-7
+# parallel_id = cairo/7
 # text = Piterning qoʻshnisi panjarani qizilga boʻyadi.
 1	Piterning	Piter	PROPN	_	Case=Gen|Number=Sing	2	nmod:poss	_	_
 2	qoʻshnisi	qoʻshni	NOUN	_	Case=Nom|Number=Sing|Poss=Yes	5	nsubj	_	_
@@ -81,6 +91,7 @@
 6	.	.	PUNCT	_	_	5	punct	_	_
 
 # sent_id = cairo-8
+# parallel_id = cairo/8
 # text = Mening dadam senikidan zoʻrroq.
 1	Mening	men	PRON	_	Case=Gen|Number=Sing|PronType=Prs	2	nmod:poss	_	_
 2	dadam	dada	NOUN	_	Case=Nom|Number=Sing|Poss=Yes	4	nsubj	_	_
@@ -89,6 +100,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = cairo-9
+# parallel_id = cairo/9
 # text = Meri bronza, Piter kumush, Jeyn oltin medalni qoʻlga kiritdi.
 1	Meri	Meri	PROPN	_	Case=Nom|Number=Sing	11	nsubj	_	_
 2	bronza	bronza	NOUN	_	Case=Nom|Number=Sing	9	amod	_	SpaceAfter=No
@@ -104,6 +116,7 @@
 12	.	.	PUNCT	_	_	11	punct	_	_
 
 # sent_id = cairo-10
+# parallel_id = cairo/10
 # text = Iguazu katta mamlakatmi yoki kichik?
 1	Iguazu	Iguazu	PROPN	_	Case=Nom|Number=Sing	3	nsubj	_	_
 2	katta	katta	ADJ	_	_	3	amod	_	_
@@ -113,6 +126,7 @@
 6	?	?	PUNCT	_	_	3	punct	_	_
 
 # sent_id = cairo-11
+# parallel_id = cairo/11
 # text = Piter Smit ham, Meri Braun ham saylana olmaydi.
 1	Piter	Piter	PROPN	_	Case=Nom|Number=Sing	9	nsubj	_	_
 2	Smit	Smit	PROPN	_	Case=Nom|Number=Sing	1	flat	_	_
@@ -126,6 +140,7 @@
 10	.	.	PUNCT	_	_	9	punct	_	_
 
 # sent_id = cairo-12.1
+# parallel_id = cairo/12/alt1
 # text = Ular kim yozganini bilmaydi.
 1	Ular	u	PRON	_	Case=Nom|Number=Plur|Person=3|PronType=Prs	4	nsubj	_	_
 2	kim	kim	PRON	_	Case=Nom|Number=Sing|PronType=Int	3	nsubj	_	_
@@ -134,6 +149,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = cairo-12.2
+# parallel_id = cairo/12/alt2
 # text = Kim yozganini bilmaydi.
 1	Kim	kim	PRON	_	Case=Nom|Number=Sing|PronType=Int	2	nsubj	_	_
 2	yozganini	yoz	VERB	_	Case=Acc|VerbForm=Part	3	ccomp	_	_
@@ -141,6 +157,7 @@
 4	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = cairo-13.1
+# parallel_id = cairo/13/alt1
 # text = Sen nimaga qarayapsan?
 1	Sen	sen	PRON	_	Case=Nom|Number=Sing|Person=2|PronType=Prs	3	nsubj	_	_
 2	nimaga	nima	PRON	_	Case=Dat|Number=Sing|PronType=Int	3	obl	_	_
@@ -148,12 +165,14 @@
 4	?	?	PUNCT	_	_	3	punct	_	_
 
 # sent_id = cairo-13.2
+# parallel_id = cairo/13/alt2
 # text = Nimaga qarayapsan?
 1	Nimaga	nima	PRON	_	Case=Dat|Number=Sing|PronType=Int	2	obl	_	_
 2	qarayapsan	qara	VERB	_	Aspect=Prog|Mood=Ind|Number=Sing|Person=2|Tense=Pres	0	root	_	SpaceAfter=No
 3	?	?	PUNCT	_	_	2	punct	_	_
 
 # sent_id = cairo-14.1
+# parallel_id = cairo/14/alt1
 # text = Sen qachon kelishing mumkin deb oʻylaysan?
 1	Sen	sen	PRON	_	Case=Nom|Number=Sing|Person=2|PronType=Prs	6	nsubj	_	_
 2	qachon	qachon	ADV	_	PronType=Int	3	advmod	_	_
@@ -164,6 +183,7 @@
 7	?	?	PUNCT	_	_	6	punct	_	_
 
 # sent_id = cairo-14.2
+# parallel_id = cairo/14/alt2
 # text = Qachon kelishing mumkin deb oʻylaysan?
 1	Qachon	qachon	ADV	_	PronType=Int	2	advmod	_	_
 2	kelishing	kel	VERB	_	VerbForm=Vnoun	5	xcomp	_	_
@@ -173,6 +193,7 @@
 6	?	?	PUNCT	_	_	5	punct	_	_
 
 # sent_id = cairo-15.1
+# parallel_id = cairo/15/alt1
 # text = U mashina oldi, lekin ukasi faqat velosiped oldi.
 1	U	u	PRON	_	Case=Nom|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	mashina	mashina	NOUN	_	Case=Nom|Number=Sing	3	obj	_	_
@@ -186,6 +207,7 @@
 10	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = cairo-15.2
+# parallel_id = cairo/15/alt2
 # text = Mashina oldi, lekin ukasi faqat velosiped oldi.
 1	Mashina	mashina	NOUN	_	Case=Nom|Number=Sing	2	obj	_	_
 2	oldi	ol	VERB	_	Mood=Ind|Number=Sing|Person=3|Tense=Past	0	root	_	SpaceAfter=No
@@ -198,6 +220,7 @@
 9	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = cairo-16
+# parallel_id = cairo/16
 # text = Piter va Meri bir-birlarini quchoqladilar va shundan soʻng xonadan chiqdilar.
 1	Piter	Piter	PROPN	_	Case=Nom|Number=Sing	5	nsubj	_	_
 2	va	va	CCONJ	_	_	3	cc	_	_
@@ -212,6 +235,7 @@
 11	.	.	PUNCT	_	_	5	punct	_	_
 
 # sent_id = cairo-17.1
+# parallel_id = cairo/17/alt1
 # text = U sochini turmaklashi kerak edi, lekin negadir oʻsha kuni turmaklamadi.
 1	U	u	PRON	_	Case=Nom|Number=Sing|Person=3|PronType=Prs	3	nsubj	_	_
 2	sochini	soch	NOUN	_	Case=Acc|Number=Sing	3	obj	_	_
@@ -227,6 +251,7 @@
 12	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = cairo-17.2
+# parallel_id = cairo/17/alt2
 # text = Sochini turmaklashi kerak edi, lekin negadir oʻsha kuni turmaklamadi.
 1	Sochini	soch	NOUN	_	Case=Acc|Number=Sing	2	obj	_	_
 2	turmaklashi	turmakla	VERB	_	Number=Sing|Person=3|VerbForm=Vnoun	0	root	_	_
@@ -241,6 +266,7 @@
 11	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = cairo-18
+# parallel_id = cairo/18
 # text = U juda tez yugurgani uchun yeta olmadim.
 1	U	u	PRON	_	Case=Nom|Number=Sing|Person=3|PronType=Prs	4	nsubj	_	_
 2	juda	juda	ADV	_	_	3	advmod	_	_
@@ -252,6 +278,7 @@
 8	.	.	PUNCT	_	_	7	punct	_	_
 
 # sent_id = cairo-19
+# parallel_id = cairo/19
 # text = Bu xat Piterdan va u kecha keldi.
 1	Bu	bu	DET	_	PronType=Dem	2	det	_	_
 2	xat	xat	NOUN	_	Case=Nom|Number=Sing	3	nsubj	_	_
@@ -263,6 +290,7 @@
 8	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = cairo-20.1
+# parallel_id = cairo/20/alt1
 # text = U Fransiya poytaxti Parijda oʻsgan.
 1	U	u	PRON	_	Case=Nom|Number=Sing|Person=3|PronType=Prs	5	nsubj	_	_
 2	Fransiya	Fransiya	PROPN	_	Case=Nom|Number=Sing	3	nmod	_	_
@@ -272,6 +300,7 @@
 6	.	.	PUNCT	_	_	5	punct	_	_
 
 # sent_id = cairo-20.2
+# parallel_id = cairo/20/alt2
 # text = Fransiya poytaxti Parijda oʻsgan.
 1	Fransiya	Fransiya	PROPN	_	Case=Nom|Number=Sing	2	nmod	_	_
 2	poytaxti	poytaxt	NOUN	_	Case=Nom|Number=Sing|Poss=Yes	3	nmod	_	_

--- a/uz_tuecl-ud-test.conllu
+++ b/uz_tuecl-ud-test.conllu
@@ -309,6 +309,7 @@
 5	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = udtw23-1
+# parallel_id = tuecl/udtw23-1
 # text = Erim chorbogʻdagi bolalar xonasini apil-tapil yigʻishtirib, oshxonadagi stolni ham chiqarib tashlabdi.
 1	Erim	er	NOUN	_	Case=Nom|Number=Sing|Poss=Yes	8	nsubj	_	_
 2	chorbogʻdagi	chorbogʻ	NOUN	_	Case=Loc|Number=Sing	4	nmod	_	_
@@ -327,6 +328,7 @@
 15	.	.	PUNCT	_	_	8	punct	_	_
 
 # sent_id = udtw23-2
+# parallel_id = tuecl/udtw23-2
 # text = Senga doim shuni aytaman, ertalab doʻsting bilan telefonda gaplashayotganingda men haqimda gapirma.
 1	Senga	sen	PRON	_	Case=Dat|Number=Sing|Person=2|PronType=Prs	4	obl	_	_
 2	doim	doim	ADV	_	_	4	advmod	_	_
@@ -344,6 +346,7 @@
 14	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = udtw23-3
+# parallel_id = tuecl/udtw23-3
 # text = Yotgani kelgan mehmon eshikni taqillatdi, lekin uy egasi hali ham tozalash ishlari bilan band edi, restorandan buyurtma qilgan taomi esa hali kelmagan edi.
 1	Yotgani	yot	VERB	_	VerbForm=Vnoun	2	advcl	_	_
 2	kelgan	kel	VERB	_	VerbForm=Part	3	acl	_	_
@@ -373,6 +376,7 @@
 26	.	.	PUNCT	_	_	5	punct	_	_
 
 # sent_id = udtw23-4
+# parallel_id = tuecl/udtw23-4
 # text = Oysha - shifokor.
 1	Oysha	Oysha	PROPN	_	Case=Nom|Number=Sing	3	nsubj	_	_
 2	-	-	PUNCT	_	_	1	punct	_	_
@@ -380,6 +384,7 @@
 4	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = udtw23-5
+# parallel_id = tuecl/udtw23-5
 # text = Biz hal qilmoqchi boʻlayotgan muammo shuki, kutubxonada hatto beshta kitobga ham joy yoʻq.
 1	Biz	biz	PRON	_	Case=Nom|Number=Plur|Person=1|PronType=Prs	3	nsubj	_	_
 2	hal	hal	PART	_	_	3	compound:lvc	_	_
@@ -398,6 +403,7 @@
 15	.	.	PUNCT	_	_	14	punct	_	_
 
 # sent_id = udtw23-6
+# parallel_id = tuecl/udtw23-6
 # text = Uning buvisi hamshira edi.
 1	Uning	u	PRON	_	Case=Gen|Number=Sing|Person=3|PronType=Prs	2	nmod:poss	_	_
 2	buvisi	buvi	NOUN	_	Case=Nom|Number=Sing|Poss=Yes	3	nsubj	_	_
@@ -406,6 +412,7 @@
 5	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = udtw23-7
+# parallel_id = tuecl/udtw23-7
 # text = Xoʻsh, javondagilar qayerda edi?
 1	Xoʻsh	xoʻsh	INTJ	_	_	4	discourse	_	SpaceAfter=No
 2	,	,	PUNCT	_	_	1	punct	_	_
@@ -415,6 +422,7 @@
 6	?	?	PUNCT	_	_	4	punct	_	_
 
 # sent_id = udtw23-8
+# parallel_id = tuecl/udtw23-8
 # text = Sude uch soatdan beri idorada yoʻq emish, Oysha ham uyda emas ekan.
 1	Sude	Sude	PROPN	_	Case=Nom|Number=Sing	6	nsubj	_	_
 2	uch	uch	NUM	_	NumType=Card	3	nummod	_	_
@@ -432,6 +440,7 @@
 14	.	.	PUNCT	_	_	6	punct	_	_
 
 # sent_id = udtw23-9
+# parallel_id = tuecl/udtw23-9
 # text = Bozorda meva bor, lekin chiroyli emas.
 1	Bozorda	bozor	NOUN	_	Case=Loc|Number=Sing	3	obl	_	_
 2	meva	meva	NOUN	_	Case=Nom|Number=Sing	3	nsubj	_	_
@@ -443,6 +452,7 @@
 8	.	.	PUNCT	_	_	3	punct	_	_
 
 # sent_id = udtw23-10
+# parallel_id = tuecl/udtw23-10
 # text = Deniz shifokor boʻladi, bilib qoʻy!
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	3	nsubj	_	_
 2	shifokor	shifokor	NOUN	_	Case=Nom|Number=Sing	3	xcomp	_	_
@@ -453,6 +463,7 @@
 7	!	!	PUNCT	_	_	6	punct	_	_
 
 # sent_id = udtw23-11
+# parallel_id = tuecl/udtw23-11
 # text = Deniz uyquda edi.
 1	Deniz	Deniz	PROPN	_	Case=Nom|Number=Sing	2	nsubj	_	_
 2	uyquda	uyqu	NOUN	_	Case=Loc|Number=Sing	0	root	_	_
@@ -460,6 +471,7 @@
 4	.	.	PUNCT	_	_	2	punct	_	_
 
 # sent_id = udtw23-12
+# parallel_id = tuecl/udtw23-12
 # text = Yigʻilish eʼlon qilinayotganda juda hayron boʻlgan boʻlsa kerak, menga tikilib qoldi.
 1	Yigʻilish	yigʻilish	NOUN	_	Case=Nom|Number=Sing	3	nsubj:pass	_	_
 2	eʼlon	eʼlon	NOUN	_	Case=Nom|Number=Sing	3	compound:lvc	_	_
@@ -476,6 +488,7 @@
 13	.	.	PUNCT	_	_	6	punct	_	_
 
 # sent_id = udtw23-13
+# parallel_id = tuecl/udtw23-13
 # text = Kardiganim uyda ekanmi?
 1	Kardiganim	kardigan	NOUN	_	Case=Nom|Number=Sing|Poss=Yes	2	nsubj	_	_
 2	uyda	uy	NOUN	_	Case=Loc|Number=Sing	0	root	_	_
@@ -483,6 +496,7 @@
 4	?	?	PUNCT	_	_	2	punct	_	_
 
 # sent_id = udtw23-14
+# parallel_id = tuecl/udtw23-14
 # text = Tadbir bugun boʻladimi?
 1	Tadbir	tadbir	NOUN	_	Case=Nom|Number=Sing	3	nsubj	_	_
 2	bugun	bugun	ADV	_	_	3	advmod	_	_
@@ -490,6 +504,7 @@
 4	?	?	PUNCT	_	_	3	punct	_	_
 
 # sent_id = udtw23-15
+# parallel_id = tuecl/udtw23-15
 # text = Natijalar eʼlon qilingan, shunday emasmi?
 1	Natijalar	natija	NOUN	_	Case=Nom|Number=Plur	3	nsubj:pass	_	_
 2	eʼlon	eʼlon	NOUN	_	Case=Nom|Number=Sing	3	compound:lvc	_	_
@@ -500,6 +515,7 @@
 7	?	?	PUNCT	_	_	6	punct	_	_
 
 # sent_id = udtw23-16
+# parallel_id = tuecl/udtw23-16
 # text = Oysha bu kitobni oʻqimagan emas.
 1	Oysha	Oysha	PROPN	_	Case=Nom|Number=Sing	4	nsubj	_	_
 2	bu	bu	DET	_	PronType=Dem	3	det	_	_
@@ -509,6 +525,7 @@
 6	.	.	PUNCT	_	_	4	punct	_	_
 
 # sent_id = udtw23-17
+# parallel_id = tuecl/udtw23-17
 # text = Umuman olganda, oʻqishni emas, rasm chizishni yaxshi koʻradi.
 1	Umuman	umuman	ADV	_	_	10	advmod	_	_
 2	olganda	ol	VERB	_	_	1	compound	_	SpaceAfter=No
@@ -523,6 +540,7 @@
 11	.	.	PUNCT	_	_	10	punct	_	_
 
 # sent_id = udtw23-18
+# parallel_id = tuecl/udtw23-18
 # text = Nimani oʻqiganini emas, nimani oʻqimoqchiligini aytyapti.
 1	Nimani	nima	PRON	_	Case=Acc|Number=Sing	2	obj	_	_
 2	oʻqiganini	oʻqi	VERB	_	Case=Acc|Number=Sing|Person=3|VerbForm=Part	7	xcomp	_	_
@@ -534,6 +552,7 @@
 8	.	.	PUNCT	_	_	7	punct	_	_
 
 # sent_id = udtw23-19
+# parallel_id = tuecl/udtw23-19
 # text = Buning koʻki chiroyliroq, menga koʻkini bera olasanmi?
 1	Buning	bu	PRON	_	Case=Gen|Number=Sing|PronType=Dem	2	nmod:poss	_	_
 2	koʻki	koʻk	ADJ	_	_	3	nsubj	_	_
@@ -546,6 +565,7 @@
 9	?	?	PUNCT	_	_	8	punct	_	_
 
 # sent_id = udtw23-20
+# parallel_id = tuecl/udtw23-20
 # text = Biz yoshlarni erisha olmaydigan maqsadlardan voz kechtirishimiz kerak.
 1	Biz	biz	PRON	_	Case=Nom|Number=Plur|Person=1|PronType=Prs	7	nsubj	_	_
 2	yoshlarni	yosh	ADJ	_	Case=Acc|Number=Plur	7	obj	_	_
@@ -558,6 +578,7 @@
 9	.	.	PUNCT	_	_	7	punct	_	_
 
 # sent_id = udtw23-21
+# parallel_id = tuecl/udtw23-21
 # text = Oʻqituvchi kitobni olib maktabga ketdi.
 1	Oʻqituvchi	oʻqituvchi	NOUN	_	Case=Nom|Number=Sing	5	nsubj	_	_
 2	kitobni	kitob	NOUN	_	Case=Acc|Number=Sing	3	obj	_	_
@@ -567,6 +588,7 @@
 6	.	.	PUNCT	_	_	5	punct	_	_
 
 # sent_id = udtw23-22
+# parallel_id = tuecl/udtw23-22
 # text = Oʻqituvchi kitobni maktabga olib ketdi.
 1	Oʻqituvchi	oʻqituvchi	NOUN	_	Case=Nom|Number=Sing	5	nsubj	_	_
 2	kitobni	kitob	NOUN	_	Case=Acc|Number=Sing	5	obj	_	_


### PR DESCRIPTION
-add parallel_id metadata format to  uz_tuecl-ud-test.conllu file:

# parallel_id = cairo/{v}/part{n} alt{n}
# parallel_id = tuecl/{v}/part{n} alt{n}

where n = any number (positive intergers, arabic numerals, starts with 1), v = any listed character (lowercase only, case sensitive)
update README with parallel corpus information: cairo, tuecl.
"Parallel: cairo tuecl"